### PR TITLE
Fix typo for: ingress ICMP - no type, no code

### DIFF
--- a/main_security_list.tf
+++ b/main_security_list.tf
@@ -545,8 +545,8 @@ resource "oci_core_security_list" "this" {
     for_each            = [for x in var.security_lists[keys(var.security_lists)[count.index]].ingress_rules != null ? var.security_lists[keys(var.security_lists)[count.index]].ingress_rules : local.default_security_list_opt.ingress_rules :
       {
         proto           : x.protocol
-        dst             : x.dst
-        dst_type        : x.dst_type
+        src             : x.src
+        src_type        : x.src_type
         stateless       : x.stateless
       } if x.protocol == "1" && x.icmp_type == null && x.icmp_code == null ]
       


### PR DESCRIPTION
When using this case `"ingress, proto: ICMP  - no type, no code"` terraform throws an error because variables are not assigned correctly in the for_each body. For ingress it needs to be `src` and `src_type` instead of `dst` and `dst_type` which is for egress.